### PR TITLE
make format function const in formatter template specialization

### DIFF
--- a/chap01/print-frac.cpp
+++ b/chap01/print-frac.cpp
@@ -30,7 +30,7 @@ struct formatter<Frac> {
     }
 
     template<typename FormatContext>
-    auto format(const Frac& f, FormatContext& ctx) {
+    auto format(const Frac& f, FormatContext& ctx) const {
         return format_to(ctx.out(), "{0:d}/{1:d}", f.n, f.d);
     }
 };


### PR DESCRIPTION
The format function in a formatter is required to be const, the code does not compile as is.